### PR TITLE
Add docker-compose.yml for easier deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  bluestone:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runner
+    ports:
+      - "3002:3002"
+    restart: always


### PR DESCRIPTION
Adding Docker compose for easy one click deployment

---

## Deployment Instructions

To deploy the Bluestone service, follow these steps:

1. Clone the repository:

```bash
git clone https://github.com/1943time/bluestone-service && cd bluestone-service
```

2. Before proceeding, ensure you have Docker installed on your system. You can install Docker using the following command:

```bash
sudo apt update -y ; sudo apt install docker-compose -y
```

3. Add docker-compose.yml if its missing 
```
version: "3.9"
services:
  bluestone:
    container_name: bluestone-service
    build:
      context: .
      dockerfile: Dockerfile
      target: runner
    ports:
      - "3002:3002"
    restart: always

```
4. Build and run the Docker container using `docker-compose`.


<details open>
<summary>Using the faster docker-compose syntax (older)</summary>

```bash
sudo docker-compose up --build
```

</details>

OR 

<details>
<summary>Using the latest docker compose syntax</summary>

To use the latest `docker compose` syntax, refer to the official documentation at <https://docs.docker.com/compose/install/> for installation instructions.

```bash
sudo docker compose up --build
```

</details>

## Exposing Bluestone Service

To expose the Bluestone service, choose one of the following methods:

<details>
<summary>Nginx Proxy Manager</summary>

1. Ensure you have Nginx Proxy Manager installed and running on your system.
2. Access the Nginx Proxy Manager dashboard and create a new Proxy Host.
3. Enter the desired domain name for the Bluestone service and set the forward hostname to the IP address of your Docker host.
4. Set the forward port to `3002` (the default Bluestone service port).
5. Save the configuration and test the domain to access the Bluestone service.

</details>

<details>
<summary>Nginx</summary>

1. Ensure you have Nginx installed on your system.
2. Create a new Nginx server block configuration file (e.g., `/etc/nginx/sites-available/bluestone.conf`).
3. Add the following configuration to the file, replacing `your_domain.com` with the desired domain name:

```nginx
server {
    listen 80;
    server_name your_domain.com;

    location / {
        proxy_pass http://docker_host_ip:3002;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}
```

4. Create a symbolic link to enable the configuration:

```bash
sudo ln -s /etc/nginx/sites-available/bluestone.conf /etc/nginx/sites-enabled/
```

5. Test the Nginx configuration and reload the service:

```bash
sudo nginx -t && sudo systemctl reload nginx
```

6. Test the domain to access the Bluestone service.

</details>

The Bluestone service has been tested and verified to work with various domain exposure methods, including Cloudflare Tunnels, Tailscale Funnel, and Traefik.